### PR TITLE
Fix arm64 builds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/caddy-dns/dnspod
 go 1.14
 
 require (
-	github.com/caddyserver/caddy/v2 v2.1.1
+	github.com/caddyserver/caddy/v2 v2.2.0-rc.1
 	github.com/libdns/dnspod v0.0.1
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/caddy-dns/dnspod
 go 1.14
 
 require (
-	github.com/caddyserver/caddy/v2 v2.2.0-rc.1
+	github.com/caddyserver/caddy/v2 v2.2.1
 	github.com/libdns/dnspod v0.0.1
 )


### PR DESCRIPTION
Caddy2 v2.1.1 is bringing in a known-to-be-broken-for-ARM64 version of cpuid. Workaround: use a version that pins the older cpuid module.